### PR TITLE
Add configurable token ids, and `get_special_tokens_mask` for masking.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 - Add `fit_on_list` to BioSequencePiece which can be trained on list of strings.
 - Make `BioSequencePiece.model_prefix` a `Union[str, Path]`, and rework internal
   implementation to be consistent.
+- Add token ids for all the special tokens (e.g. `bos_token` now has an
+  accompanying `bos_token_id`).
+- Add `special_token_ids` returns the set of integers that are special tokens.
+- Add a `get_special_tokens_mask` method on the tokenizer that returns a [0, 1]
+  mask of the underlying tokens.
 
 ## 0.12.0 (2020-01-25)
 

--- a/gcgc/tokenizer/base.py
+++ b/gcgc/tokenizer/base.py
@@ -14,15 +14,56 @@ from pydantic import root_validator
 class SequenceTokenizerSettings(BaseSettings):
     """The base tokenizer settings."""
 
+    unk_token: Optional[str] = Field(None, env="GCGC_UNK_TOKEN")
+    unk_token_id: Optional[int] = Field(None, env="GCGC_UNK_TOKEN_ID")
+
     bos_token: Optional[str] = Field(None, env="GCGC_BOS_TOKEN")
-    eos_token: Optional[str] = Field(None, env="GCGC_EOS_TOKEN")
-    unk_token: Optional[str] = Field("?", env="GCGC_UNK_TOKEN")
+    bos_token_id: Optional[int] = Field(None, env="GCGC_BOS_TOKEN_ID")
+
     mask_token: Optional[str] = Field(None, env="GCGC_MASK_TOKEN")
+    mask_token_id: Optional[int] = Field(None, env="GCGC_MASK_TOKEN_ID")
+
+    eos_token: Optional[str] = Field(None, env="GCGC_EOS_TOKEN")
+    eos_token_id: Optional[int] = Field(None, env="GCGC_EOS_TOKEN_ID")
+
     pad_token: Optional[str] = Field(None, env="GCGC_PAD_TOKEN")
+    pad_token_id: Optional[int] = Field(None, env="GCGC_PAD_TOKEN_ID")
 
     max_length: Optional[int] = Field(None, env="GCGC_MAX_LENGTH")
     min_length: Optional[int] = Field(None, env="GCGC_MIN_LENGTH")
+
     conform_length: Optional[int] = Field(None, env="GCGC_CONFORM_LENGTH")
+
+    # pylint: disable=no-self-argument, no-self-use
+    @root_validator
+    def validate_and_set_special_tokens(cls, values):
+        """Check that the tokens and token id pairs have corresponding values.
+
+        If they do not, this will set the default value.
+
+        """
+        special_token_defaults = [
+            ("pad_token", "|", 0),
+            ("bos_token", ">", 1),
+            ("eos_token", "<", 2),
+            ("unk_token", "?", 3),
+        ]
+        for token_name, token_char, token_id in special_token_defaults:
+            passed_token = values.get(token_name)
+            passed_token_id = values.get(f"{token_name}_id")
+
+            if (passed_token is None and passed_token_id is None) or (
+                passed_token is not None and passed_token_id is not None
+            ):
+                continue
+
+            if passed_token is None and passed_token_id is not None:
+                values[token_name] = token_char
+
+            if passed_token is not None and passed_token_id is None:
+                values[f"{token_name}_id"] = token_id
+
+        return values
 
     @root_validator
     def validate_lengths(cls, values):  # pylint: disable=no-self-argument, no-self-use
@@ -45,6 +86,36 @@ class SequenceTokenizerSettings(BaseSettings):
 
         return values
 
+    @property
+    def special_token_ids(self) -> List[int]:
+        """Return the list of token ids corresponding to special tokens."""
+        return [
+            x
+            for x in [
+                self.bos_token_id,
+                self.eos_token_id,
+                self.unk_token_id,
+                self.pad_token_id,
+                self.mask_token_id,
+            ]
+            if x is not None
+        ]
+
+    @property
+    def special_tokens(self) -> List[str]:
+        """Return the set of special tokens that are not None."""
+        return [
+            x
+            for x in [
+                self.bos_token,
+                self.eos_token,
+                self.unk_token,
+                self.pad_token,
+                self.mask_token,
+            ]
+            if x is not None
+        ]
+
 
 def _pad_token_list(tokens: List[str], pad_to: int, pad_char: str):
     """Pad the input tokens list to tokens."""
@@ -61,11 +132,19 @@ class SequenceTokenizer:
     """The sequence tokenizer object."""
 
     def __init__(self, settings: Optional[SequenceTokenizerSettings] = None):
-        """Inits the sequence tokenizer with a set of settings."""
+        """Init the sequence tokenizer with a set of settings."""
         self.settings = settings or SequenceTokenizerSettings()
 
-    def apply_length_constraints(self, tokens: List[str]):
-        """Apply the constraints of the settings to the passed tokens list."""
+    def get_special_tokens_mask(self, token_ids: List[int]) -> List[int]:
+        """Given the input set of tokens, return a list that demarcates special character.
+
+        Returns:
+            A list of 0s and 1s, where the value is one if the token is a special character.
+        """
+        return [token_id in self.settings.special_token_ids for token_id in token_ids]
+
+    def apply_length_constraints(self, tokens: List[str]) -> List[str]:
+        """Apply the constraints from the settings to the passed tokens list."""
         if self.settings.conform_length:
             tokens = _pad_token_list(tokens, self.settings.conform_length, self.settings.pad_token)
             return tokens[: self.settings.conform_length]

--- a/gcgc/tokenizer/base.py
+++ b/gcgc/tokenizer/base.py
@@ -140,6 +140,7 @@ class SequenceTokenizer:
 
         Returns:
             A list of 0s and 1s, where the value is one if the token is a special character.
+
         """
         return [token_id in self.settings.special_token_ids for token_id in token_ids]
 

--- a/gcgc/tokenizer/kmer_tokenzier.py
+++ b/gcgc/tokenizer/kmer_tokenzier.py
@@ -84,7 +84,7 @@ class KmerTokenizer(SequenceTokenizer):
         for letter in self.encode_as_tokens(seq):
             try:
                 if self.vocab[letter] == 2 and letter == ">":
-                    __import__('ipdb').set_trace()
+                    __import__("ipdb").set_trace()
                 encoded.append(self.vocab[letter])
             except KeyError:
                 if add_unknown:

--- a/gcgc/tokenizer/kmer_tokenzier.py
+++ b/gcgc/tokenizer/kmer_tokenzier.py
@@ -3,6 +3,7 @@
 """Module for KMER tokenization."""
 
 import itertools as it
+from typing import Dict
 from typing import List
 from typing import Optional
 
@@ -26,39 +27,26 @@ class KmerTokenizerSettings(SequenceTokenizerSettings):
         """Resolve the alphabet if it's a named alphabet."""
         return alphabets.resolve_alphabet(alphabet)
 
-    @property
-    def special_tokens(self) -> List[str]:
-        """Return the list of special tokens that are not None."""
-        return [
-            x
-            for x in [
-                self.bos_token,
-                self.eos_token,
-                self.unk_token,
-                self.pad_token,
-                self.mask_token,
-            ]
-            if x is not None
-        ]
 
-
-def _create_kmer_vocab_from_token(
-    alphabet, kmer_length, token_characters: Optional[List[str]] = None
-):
+def _create_kmer_vocab_from_token(settings: KmerTokenizerSettings) -> Dict[str, int]:
     """Create vocabulary object from a list of tokens."""
-    if token_characters is None:
-        token_characters = []
-
     token_to_int = {}
 
-    for i, token in enumerate(token_characters):
-        token_to_int[token] = i
+    for token_id, token in zip(settings.special_token_ids, settings.special_tokens):
+        token_to_int[token] = token_id
 
-    token_list = ["".join(kmer) for kmer in it.product(list(alphabet), repeat=kmer_length)]
-    for i, token in enumerate(token_list, start=len(token_characters)):
-        token_to_int[token] = i
+    token_set = [
+        "".join(kmer) for kmer in it.product(list(settings.alphabet), repeat=settings.kmer_length)
+    ]
 
-    # pylint: disable=too-many-function-args
+    starting_value = 0
+    for token in token_set:
+        while starting_value in settings.special_token_ids:
+            starting_value += 1
+
+        token_to_int[token] = starting_value
+        starting_value += 1
+
     return token_to_int
 
 
@@ -76,9 +64,7 @@ class KmerTokenizer(SequenceTokenizer):
         self.settings = settings or KmerTokenizerSettings()
         super().__init__(settings)
 
-        self.vocab = _create_kmer_vocab_from_token(
-            self.settings.alphabet, self.settings.kmer_length, self.settings.special_tokens
-        )
+        self.vocab = _create_kmer_vocab_from_token(self.settings)
 
     def _kmer_n(self, seq: str) -> List[str]:
         seq_len = len(seq)
@@ -91,12 +77,27 @@ class KmerTokenizer(SequenceTokenizer):
 
         return kmers
 
-    def encode(self, seq: str) -> List[int]:
+    def encode(self, seq: str, add_unknown: bool = False) -> List[int]:
         """Encode the underlying sequence into a list of tokens."""
-        return [
-            self.vocab.get(s, self.vocab.get(self.settings.unk_token))
-            for s in self.encode_as_tokens(seq)
-        ]
+        encoded = []
+
+        for letter in self.encode_as_tokens(seq):
+            try:
+                if self.vocab[letter] == 2 and letter == ">":
+                    __import__('ipdb').set_trace()
+                encoded.append(self.vocab[letter])
+            except KeyError:
+                if add_unknown:
+                    encoded.append(self.settings.unk_token_id)
+                else:
+                    raise
+
+        return encoded
+
+        # return [
+        # self.vocab.get(s, self.vocab.get(self.settings.unk_token))
+        # for s in self.encode_as_tokens(seq)
+        # ]
 
     def encode_as_tokens(self, seq: str) -> List[str]:
         """Tokenize the sequence into a list of token tokens.

--- a/gcgc/tokenizer/sentence_piece_tokenizer.py
+++ b/gcgc/tokenizer/sentence_piece_tokenizer.py
@@ -10,12 +10,12 @@ from typing import List
 from typing import Optional
 from typing import Union
 
+from Bio import SeqIO
+from pydantic import Field
 from typing_extensions import Literal
 
-from Bio import SeqIO
 from gcgc.tokenizer.base import SequenceTokenizer
 from gcgc.tokenizer.base import SequenceTokenizerSettings
-from pydantic import Field
 
 try:
     import sentencepiece as spm

--- a/gcgc/tokenizer/sentence_piece_tokenizer.py
+++ b/gcgc/tokenizer/sentence_piece_tokenizer.py
@@ -10,12 +10,12 @@ from typing import List
 from typing import Optional
 from typing import Union
 
-from pydantic import Field
 from typing_extensions import Literal
 
 from Bio import SeqIO
 from gcgc.tokenizer.base import SequenceTokenizer
 from gcgc.tokenizer.base import SequenceTokenizerSettings
+from pydantic import Field
 
 try:
     import sentencepiece as spm
@@ -38,6 +38,9 @@ class BioSequencePieceSettings(SequenceTokenizerSettings):
         16, description="The number of threads to use.", env="GCGC_SP_NUM_THREADS"
     )
     num_sub_iterations: int = Field(2, env="GCGC_SP_NUM_SUB_ITERATIONS")
+
+    unk_token: Optional[str] = Field("?", env="GCGC_UNK_TOKEN")
+    unk_token_id: Optional[int] = Field(0, env="GCGC_UNK_TOKEN_ID")
 
     @property
     def _model_prefix_path(self) -> Path:
@@ -119,6 +122,8 @@ class BioSequencePiece(SequenceTokenizer):
             f"--max_sentence_length={self.settings.max_sequence_length}",
             f"--num_sub_iterations={self.settings.num_sub_iterations}",
             f"--num_threads={self.settings.num_threads}",
+            f"--unk_piece={self.settings.unk_token}",
+            f"--unk_id={self.settings.unk_token_id}",
         ]
 
         if self.settings.unk_token:


### PR DESCRIPTION
```diff
diff --git a/CHANGELOG.md b/CHANGELOG.md
index 938caeb..205d45c 100644
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 - Add `fit_on_list` to BioSequencePiece which can be trained on list of strings.
 - Make `BioSequencePiece.model_prefix` a `Union[str, Path]`, and rework internal
   implementation to be consistent.
+- Add token ids for all the special tokens (e.g. `bos_token` now has an
+  accompanying `bos_token_id`).
+- Add `special_token_ids` returns the set of integers that are special tokens.
+- Add a `get_special_tokens_mask` method on the tokenizer that returns a [0, 1]
+  mask of the underlying tokens.

 ## 0.12.0 (2020-01-25)

```