### PR TITLE
Add a Vocab object to facilitate easier stoi/itos usage.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   an inferred token.
 - Add `pad_at_end` boolean setting that when True pads at the end of the
   sequence, and when False pads at the beginning.
+- Add dedicated `Vocab` object which replaces the dictionary of string to
+  integer.
 
 ## 0.12.1 (2020-02-16)
 

--- a/gcgc/tests/vocab/test_vocab.py
+++ b/gcgc/tests/vocab/test_vocab.py
@@ -1,0 +1,22 @@
+# (c) Copyright 2020 Trent Hauck
+# All Rights Reserved
+"""Test the vocabulary object."""
+
+from gcgc.vocab import Vocab
+
+
+def test_vocab():
+    """Test the vocabulary object works as expected."""
+    vocab = Vocab()
+
+    vocab.add_item("A")
+
+    assert "A" in vocab
+    assert vocab["A"] == 0
+
+    vocab.add_items(["T", "C"])
+
+    assert "T" in vocab
+    assert "C" in vocab
+
+    assert vocab.stoi == {"A": 0, "T": 1, "C": 2}

--- a/gcgc/tokenizer/kmer_tokenzier.py
+++ b/gcgc/tokenizer/kmer_tokenzier.py
@@ -23,7 +23,6 @@ encoded sequences will be codons (in the loose sense) with a vocabulary of size 
 """
 
 import itertools as it
-from typing import Dict
 from typing import List
 from typing import Optional
 
@@ -33,6 +32,7 @@ from pydantic import validator
 from gcgc import alphabets
 from gcgc.tokenizer.base import SequenceTokenizer
 from gcgc.tokenizer.base import SequenceTokenizerSettings
+from gcgc.vocab import Vocab
 
 
 class KmerTokenizerSettings(SequenceTokenizerSettings):
@@ -69,12 +69,12 @@ class KmerTokenizerSettings(SequenceTokenizerSettings):
         return alphabets.resolve_alphabet(alphabet)
 
 
-def _create_kmer_vocab_from_token(settings: KmerTokenizerSettings) -> Dict[str, int]:
+def _create_kmer_vocab_from_token(settings: KmerTokenizerSettings) -> Vocab:
     """Create the vocab object from a list of tokens."""
-    token_to_int = {}
+    vocab = Vocab()
 
     for token_id, token in zip(settings.special_token_ids, settings.special_tokens):
-        token_to_int[token] = token_id
+        vocab[token] = token_id
 
     token_set = [
         "".join(kmer) for kmer in it.product(list(settings.alphabet), repeat=settings.kmer_length)
@@ -85,10 +85,10 @@ def _create_kmer_vocab_from_token(settings: KmerTokenizerSettings) -> Dict[str, 
         while starting_value in settings.special_token_ids:
             starting_value += 1
 
-        token_to_int[token] = starting_value
+        vocab[token] = starting_value
         starting_value += 1
 
-    return token_to_int
+    return vocab
 
 
 class KmerTokenizer(SequenceTokenizer):

--- a/gcgc/vocab.py
+++ b/gcgc/vocab.py
@@ -1,0 +1,58 @@
+# (c) Copyright 2020 Trent Hauck
+# All Rights Reserved
+"""The Vocab object holds the vocabulary for the tokenizer."""
+
+import typing
+
+import pydantic
+
+# pylint: disable=unsupported-membership-test
+# pylint: disable=unsupported-assignment-operation
+# pylint: disable=unsubscriptable-object
+# pylint: disable=no-member
+
+
+class Vocab(pydantic.BaseModel):
+    """The Vocab object that holds the mapping between integers and characters."""
+
+    stoi: typing.Dict[str, int] = None
+
+    # pylint: disable=no-self-argument,no-self-use
+    @pydantic.validator("stoi", pre=True, always=True)
+    def default_stoi(cls, value) -> typing.Dict[str, int]:
+        """Get the default string to integer mapping."""
+        return {} if value is None else value
+
+    @property
+    def itos(self):
+        """Return the integer to string mapping of the underlying stoi."""
+        return {integer: string for string, integer in self.stoi.items()}
+
+    def __getitem__(self, item: str) -> int:
+        """Get the item from the vocab."""
+        return self.stoi[item]
+
+    def __contains__(self, item: str) -> bool:
+        """Return True if the item is in the vocab."""
+        return item in self.stoi
+
+    def __len__(self) -> int:
+        """Return the size of the vocabulary."""
+        return len(self.stoi)
+
+    def __setitem__(self, item: str, value: int) -> None:
+        """Add an item to the vocabulary with a specific value."""
+        self.stoi[item] = value
+
+    def add_item(self, item: str) -> None:
+        """Add an item to the vocabulary."""
+        try:
+            current_max = max(self.stoi.values())
+            self.stoi[item] = current_max + 1
+        except ValueError:
+            self.stoi[item] = 0
+
+    def add_items(self, items: typing.Iterable[str]) -> None:
+        """Add multiple items to the vocabulary in one fell swoop."""
+        for item in items:
+            self.add_item(item)


### PR DESCRIPTION
```diff
diff --git a/CHANGELOG.md b/CHANGELOG.md
index 0377651..ffadcef 100644
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   an inferred token.
 - Add `pad_at_end` boolean setting that when True pads at the end of the
   sequence, and when False pads at the beginning.
+- Add dedicated `Vocab` object which replaces the dictionary of string to
+  integer.

 ## 0.12.1 (2020-02-16)

```